### PR TITLE
chore: added db connection

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -23,6 +23,20 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: rbi_inventory_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,7 +58,7 @@ jobs:
       - name: Generate OpenAPI spec
         run: pnpm --filter @rbi/api openapi:generate
         env:
-          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          DATABASE_URL: postgresql://test:test@localhost:5432/rbi_inventory_test
           CLERK_SECRET_KEY: sk_test_dummy_key_for_openapi_generation
 
       - name: Regenerate frontend API client

--- a/modules/api/src/scripts/generate-openapi.ts
+++ b/modules/api/src/scripts/generate-openapi.ts
@@ -8,7 +8,7 @@ import { AppModule } from 'src/app.module';
 
 async function generateOpenApi() {
   const app = await NestFactory.create(AppModule, {
-    logger: false,
+    logger: ['error', 'warn'],
   });
 
   app.useGlobalPipes(


### PR DESCRIPTION
## Description

Add PostgreSQL service to OpenAPI workflow and improve logging during generation

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Configuration/infrastructure change

## Changes Made

- Added PostgreSQL service to the OpenAPI GitHub workflow
- Updated database connection string to use the PostgreSQL service instead of dummy values
- Enabled error and warning logs during OpenAPI generation for better debugging

## Checklist

### General
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

### API Changes (if applicable)
- [x] I have regenerated the OpenAPI spec (`pnpm --filter @rbi/api openapi:generate`)

### Testing
- [x] I have tested the changes in a local environment

## Additional Notes

This change ensures that the OpenAPI generation workflow has a real PostgreSQL database to connect to, which should resolve issues with schema validation during the generation process.