### PR TITLE
Update dependabot configuration to limit PRs to 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,14 @@
 version: 2
 updates:
-  # Root package.json
+  # Root package.json – no PRs, just alerts
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "automated"
@@ -15,7 +16,6 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
     ignore:
-      # Ignore major version updates for now
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
@@ -26,7 +26,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "api"
@@ -45,7 +46,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "web"
@@ -64,7 +66,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 3
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "types"
@@ -80,7 +83,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 3
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "config"
@@ -96,7 +100,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "ci/cd"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to stop Dependabot from opening pull requests for dependency updates and instead only send alerts. It also sets the timezone for scheduled updates to "Europe/Berlin" for all monitored package ecosystems.

Dependabot configuration changes:

* Set `open-pull-requests-limit` to `0` for all package ecosystems, so Dependabot will no longer create pull requests for updates, only alerts. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L29-R30) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L48-R50) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L67-R70) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L83-R87) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L99-R104)
* Added `timezone: "Europe/Berlin"` to all update schedules to ensure updates are checked according to the specified timezone. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L29-R30) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L48-R50) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L67-R70) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L83-R87) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L99-R104)
* Updated the comment for the root `package.json` configuration to clarify that no PRs will be created, just alerts.