### PR TITLE
fix: release cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,5 +247,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: web-dist
-          path: modules/web/.next/
+          path: modules/web/dist/
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*'        # Stable releases
+      - 'v*-alpha*' # Alpha releases
+      - 'v*-beta*'  # Beta releases
   workflow_dispatch:
 
 permissions:
@@ -181,14 +183,21 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          tar -czf dist/rbi-remote-desktop-${{ matrix.asset_name }}.tar.gz \
-            -C modules/remote-desktop/src-tauri/target/release/bundle .
+          cd modules/remote-desktop/src-tauri/target/release/bundle
+          # Extract specific installers based on platform
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            find . -name "*.deb" -o -name "*.AppImage" | xargs -I {} cp {} $GITHUB_WORKSPACE/dist/
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            find . -name "*.dmg" -o -name "*.app" | xargs -I {} cp -r {} $GITHUB_WORKSPACE/dist/
+          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            find . -name "*.msi" -o -name "*.exe" | xargs -I {} cp {} $GITHUB_WORKSPACE/dist/
+          fi
 
       - name: Upload desktop app
         uses: actions/upload-artifact@v4
         with:
           name: rbi-remote-desktop-${{ matrix.asset_name }}
-          path: dist/rbi-remote-desktop-${{ matrix.asset_name }}.tar.gz
+          path: dist/*
 
   docker:
     name: Build and push Docker images
@@ -203,6 +212,8 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -226,6 +237,7 @@ jobs:
           context: .
           file: modules/api/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_server.outputs.tags }}
           labels: ${{ steps.meta_server.outputs.labels }}
 
@@ -244,6 +256,7 @@ jobs:
           context: .
           file: modules/web/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_remote.outputs.tags }}
           labels: ${{ steps.meta_remote.outputs.labels }}
 
@@ -263,16 +276,25 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum * > checksums.txt
+          cat checksums.txt
+
+      - name: Report artifact sizes
+        run: |
+          echo "## Release Artifact Sizes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Artifact | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|------|" >> $GITHUB_STEP_SUMMARY
+          cd dist
+          ls -lh | grep -v '^d' | awk '{printf "| %s | %s |\n", $9, $5}' >> $GITHUB_STEP_SUMMARY
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           files: |
-            dist/rbi-server-dist.tar.gz
-            dist/rbi-remote-web.tar.gz
-            dist/rbi-server-linux-x64.tar.gz
-            dist/rbi-server-macos-x64.tar.gz
-            dist/rbi-server-windows-x64.tar.gz
-            dist/rbi-remote-desktop-linux-x64.tar.gz
-            dist/rbi-remote-desktop-macos-x64.tar.gz
-            dist/rbi-remote-desktop-windows-x64.tar.gz
-            dist/openapi.yaml
+            dist/*

--- a/modules/remote-desktop/src-tauri/tauri.conf.json
+++ b/modules/remote-desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.rbi.inventory.remote",
   "build": {
     "frontendDist": "../src-ui",
-    "devPath": "http://localhost:1420"
+    "devUrl": "http://localhost:1420"
   },
   "app": {
     "windows": [

--- a/modules/web/Dockerfile
+++ b/modules/web/Dockerfile
@@ -47,7 +47,7 @@ COPY modules/web/package.json ./modules/web/
 RUN pnpm install --frozen-lockfile --prod
 
 # Copy built artifacts from builder
-COPY --from=builder /app/modules/web/.output ./modules/web/.output
+COPY --from=builder /app/modules/web/dist ./modules/web/dist
 COPY --from=builder /app/modules/web/public ./modules/web/public
 
 # Set environment variables

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "node .output/server/index.mjs",
+    "start": "node dist/server/server.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
This pull request updates the build and release workflows for both the web and desktop applications, improving artifact handling, release automation, and multi-platform support. It also includes minor configuration fixes to ensure consistency across the build pipeline.

**CI/CD Workflow Improvements:**

- **Artifact Paths and Docker Build Updates:**
  - Changed the web build artifact path from `.next/` to `dist/` in both the CI workflow and the Dockerfile to standardize output locations. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL250-R250) [[2]](diffhunk://#diff-910ae4dc0c4040978e12af153054f29e61645f5995d680d453e0bddd37b07f40L50-R50)
  - Updated the web app's start script in `package.json` to use `dist/server/server.js` instead of `.output/server/index.mjs`.

- **Release Workflow Enhancements:**
  - Modified the release workflow to handle stable, alpha, and beta tags, enabling prerelease detection and notes generation. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L6-R8) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R279-R300)
  - Changed the packaging of desktop app installers to copy platform-specific binaries (e.g., `.deb`, `.AppImage`, `.dmg`, `.msi`, `.exe`) directly into the `dist` directory, replacing the previous tarball approach.
  - Added steps to generate SHA256 checksums for release artifacts and to report artifact sizes in the GitHub Actions summary.
  - Updated Docker build and push steps to support multi-platform builds (`linux/amd64,linux/arm64`) for both API and web modules. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R215-R216) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R240) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R259)

**Configuration Fixes:**

- **Tauri Configuration:**
  - Corrected the Tauri config to use `devUrl` instead of the deprecated `devPath` property.