### PR TITLE
feat: added audit logs page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,24 @@ Orders, Photos, StockMovements, Suppliers, Clients — these have entity definit
 5. **Shared DTOs/enums** in `packages/types/src/<feature>/` — rebuild with `pnpm --filter @librestock/types build`
 6. **Frontend hooks** in `web/src/lib/data/<feature>.ts`
 
+## Testing
+
+| Module | Framework | Unit Tests | E2E Tests |
+| ------ | --------- | ---------- | --------- |
+| API | Jest 30 (`ts-jest`) | `src/routes/*/*.spec.ts` | `test/*.e2e-spec.ts` |
+| Web | Playwright | — | `e2e/tests/*.spec.ts` |
+
+```bash
+pnpm --filter @librestock/api test                    # API unit tests
+pnpm --filter @librestock/api test:e2e                # API e2e tests (needs DB)
+pnpm --filter @librestock/web test:e2e                # Playwright (needs devenv up)
+```
+
+**Note:** Jest 30 renamed `--testPathPattern` to `--testPathPatterns` (plural). Use:
+```bash
+pnpm --filter @librestock/api test --testPathPatterns='audit'
+```
+
 ## Module Documentation
 
 - `modules/api/CLAUDE.md` - Backend patterns, entities, endpoints

--- a/modules/api/CLAUDE.md
+++ b/modules/api/CLAUDE.md
@@ -264,6 +264,50 @@ The transaction interceptor automatically wraps decorated methods in TypeORM tra
 | PATCH  | `/api/v1/inventory/:id/adjust` | Adjust quantity   |
 | DELETE | `/api/v1/inventory/:id`      | Delete              |
 
+### Audit Logs
+
+| Method | Path                                              | Description                | Auth         |
+| ------ | ------------------------------------------------- | -------------------------- | ------------ |
+| GET    | `/api/v1/audit-logs`                              | List (paginated, filtered) | Admin only   |
+| GET    | `/api/v1/audit-logs/:id`                          | Get one                    | Admin only   |
+| GET    | `/api/v1/audit-logs/entity/:entityType/:entityId` | Entity audit history       | Admin only   |
+| GET    | `/api/v1/audit-logs/user/:userId`                 | User audit history         | Admin only   |
+
+**Note:** All audit-log endpoints are restricted to `@Roles(UserRole.ADMIN)`. Non-admin users receive 403.
+
+## Testing
+
+### Unit Tests (Jest 30)
+
+Config is inline in `package.json`. Test files: `src/**/*.spec.ts`
+
+```bash
+pnpm test                                        # All unit tests
+pnpm test --testPathPatterns='audit'              # Filter by path
+pnpm test:cov                                    # With coverage
+```
+
+**Important:** Jest 30 uses `--testPathPatterns` (plural), not `--testPathPattern`.
+
+**Patterns:**
+- Use `@nestjs/testing` `Test.createTestingModule()` for DI
+- Mock repositories with `jest.fn()` + `mockResolvedValue()`
+- Test util: `src/test-utils/execution-context.ts` for mocking `ExecutionContext`
+
+### E2E Tests (Jest + Supertest)
+
+Config: `test/jest-e2e.json`. Test files: `test/*.e2e-spec.ts`
+
+```bash
+pnpm test:e2e                                    # Requires running DB
+```
+
+**Patterns:**
+- Boot full NestJS app with `Test.createTestingModule({ imports: [AppModule] })`
+- Override `AuthGuard` with mock: `.overrideGuard(AuthGuard).useValue(mockAuthGuard)`
+- Clean DB in `beforeEach` with raw SQL deletes
+- Use `supertest` for HTTP assertions
+
 ## Environment Variables
 
 ```bash

--- a/modules/api/src/routes/audit-logs/audit-log.repository.spec.ts
+++ b/modules/api/src/routes/audit-logs/audit-log.repository.spec.ts
@@ -1,0 +1,310 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditAction, AuditEntityType } from 'src/common/enums';
+import { AuditLog } from './entities/audit-log.entity';
+import { AuditLogRepository } from './audit-log.repository';
+
+describe('AuditLogRepository', () => {
+  let repository: AuditLogRepository;
+  let typeormRepository: Record<string, jest.Mock>;
+
+  const mockAuditLog: AuditLog = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    user_id: 'user_123',
+    action: AuditAction.CREATE,
+    entity_type: AuditEntityType.PRODUCT,
+    entity_id: '660e8400-e29b-41d4-a716-446655440000',
+    changes: null,
+    ip_address: '192.168.1.1',
+    user_agent: 'Mozilla/5.0',
+    created_at: new Date('2024-01-01'),
+  };
+
+  const mockQueryBuilder = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getCount: jest.fn(),
+    getMany: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    typeormRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditLogRepository,
+        {
+          provide: getRepositoryToken(AuditLog),
+          useValue: typeormRepository,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<AuditLogRepository>(AuditLogRepository);
+
+    jest.clearAllMocks();
+    // Reset query builder mocks after clearAllMocks
+    mockQueryBuilder.andWhere.mockReturnThis();
+    mockQueryBuilder.orderBy.mockReturnThis();
+    mockQueryBuilder.skip.mockReturnThis();
+    mockQueryBuilder.take.mockReturnThis();
+    typeormRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create and save an audit log', async () => {
+      typeormRepository.create.mockReturnValue(mockAuditLog);
+      typeormRepository.save.mockResolvedValue(mockAuditLog);
+
+      const data = {
+        user_id: 'user_123',
+        action: AuditAction.CREATE,
+        entity_type: AuditEntityType.PRODUCT,
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      };
+
+      const result = await repository.create(data);
+
+      expect(typeormRepository.create).toHaveBeenCalledWith(data);
+      expect(typeormRepository.save).toHaveBeenCalledWith(mockAuditLog);
+      expect(result).toEqual(mockAuditLog);
+    });
+  });
+
+  describe('createMany', () => {
+    it('should create and save multiple audit logs', async () => {
+      const dataArray = [
+        {
+          user_id: 'user_123',
+          action: AuditAction.DELETE,
+          entity_type: AuditEntityType.PRODUCT,
+          entity_id: 'id-1',
+        },
+        {
+          user_id: 'user_123',
+          action: AuditAction.DELETE,
+          entity_type: AuditEntityType.PRODUCT,
+          entity_id: 'id-2',
+        },
+      ];
+      const mockLogs = dataArray.map((d, i) => ({
+        ...mockAuditLog,
+        id: `id-${i}`,
+        ...d,
+      }));
+
+      typeormRepository.create.mockReturnValue(mockLogs);
+      typeormRepository.save.mockResolvedValue(mockLogs);
+
+      const result = await repository.createMany(dataArray);
+
+      expect(typeormRepository.create).toHaveBeenCalledWith(dataArray);
+      expect(typeormRepository.save).toHaveBeenCalledWith(mockLogs);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('findByEntityId', () => {
+    it('should find logs by entity type and id', async () => {
+      const logs = [mockAuditLog];
+      typeormRepository.find.mockResolvedValue(logs);
+
+      const result = await repository.findByEntityId(
+        AuditEntityType.PRODUCT,
+        '660e8400-e29b-41d4-a716-446655440000',
+      );
+
+      expect(typeormRepository.find).toHaveBeenCalledWith({
+        where: {
+          entity_type: AuditEntityType.PRODUCT,
+          entity_id: '660e8400-e29b-41d4-a716-446655440000',
+        },
+        order: { created_at: 'DESC' },
+      });
+      expect(result).toEqual(logs);
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('should find logs by user id', async () => {
+      const logs = [mockAuditLog];
+      typeormRepository.find.mockResolvedValue(logs);
+
+      const result = await repository.findByUserId('user_123');
+
+      expect(typeormRepository.find).toHaveBeenCalledWith({
+        where: { user_id: 'user_123' },
+        order: { created_at: 'DESC' },
+      });
+      expect(result).toEqual(logs);
+    });
+  });
+
+  describe('findPaginated', () => {
+    it('should return paginated results with defaults', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(1);
+      mockQueryBuilder.getMany.mockResolvedValue([mockAuditLog]);
+
+      const result = await repository.findPaginated({});
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'audit_log.created_at',
+        'DESC',
+      );
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(20);
+      expect(result).toEqual({
+        data: [mockAuditLog],
+        total: 1,
+        page: 1,
+        limit: 20,
+        total_pages: 1,
+      });
+    });
+
+    it('should apply entity_type filter', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await repository.findPaginated({
+        entity_type: AuditEntityType.CATEGORY,
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.entity_type = :entity_type',
+        { entity_type: AuditEntityType.CATEGORY },
+      );
+    });
+
+    it('should apply action filter', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await repository.findPaginated({
+        action: AuditAction.UPDATE,
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.action = :action',
+        { action: AuditAction.UPDATE },
+      );
+    });
+
+    it('should apply entity_id filter', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await repository.findPaginated({
+        entity_id: 'entity-123',
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.entity_id = :entity_id',
+        { entity_id: 'entity-123' },
+      );
+    });
+
+    it('should apply user_id filter', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await repository.findPaginated({
+        user_id: 'user-123',
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.user_id = :user_id',
+        { user_id: 'user-123' },
+      );
+    });
+
+    it('should apply date range filters', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      const fromDate = new Date('2024-01-01');
+      const toDate = new Date('2024-12-31');
+
+      await repository.findPaginated({
+        from_date: fromDate,
+        to_date: toDate,
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.created_at >= :from_date',
+        { from_date: fromDate },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'audit_log.created_at <= :to_date',
+        { to_date: toDate },
+      );
+    });
+
+    it('should apply all filters simultaneously', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(0);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await repository.findPaginated({
+        entity_type: AuditEntityType.PRODUCT,
+        entity_id: 'entity-123',
+        user_id: 'user-123',
+        action: AuditAction.UPDATE,
+        from_date: new Date('2024-01-01'),
+        to_date: new Date('2024-12-31'),
+        page: 2,
+        limit: 50,
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledTimes(6);
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(50);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(50);
+    });
+
+    it('should calculate correct pagination offset', async () => {
+      mockQueryBuilder.getCount.mockResolvedValue(100);
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      const result = await repository.findPaginated({
+        page: 3,
+        limit: 10,
+      });
+
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(20);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+      expect(result.total_pages).toBe(10);
+    });
+  });
+
+  describe('findById', () => {
+    it('should find audit log by id', async () => {
+      typeormRepository.findOneBy.mockResolvedValue(mockAuditLog);
+
+      const result = await repository.findById(mockAuditLog.id);
+
+      expect(typeormRepository.findOneBy).toHaveBeenCalledWith({
+        id: mockAuditLog.id,
+      });
+      expect(result).toEqual(mockAuditLog);
+    });
+
+    it('should return null when not found', async () => {
+      typeormRepository.findOneBy.mockResolvedValue(null);
+
+      const result = await repository.findById('non-existent');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/modules/api/test/audit-logs.e2e-spec.ts
+++ b/modules/api/test/audit-logs.e2e-spec.ts
@@ -1,0 +1,329 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { type INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { type Repository } from 'typeorm';
+import { AuthGuard } from '@thallesp/nestjs-better-auth';
+import { AppModule } from '../src/app.module';
+import { AuditLog } from '../src/routes/audit-logs/entities/audit-log.entity';
+import { AuditAction, AuditEntityType } from '../src/common/enums';
+
+describe('AuditLogsController (e2e)', () => {
+  let app: INestApplication;
+  let auditLogRepository: Repository<AuditLog>;
+  let authToken: string;
+
+  const mockAuthGuard = {
+    canActivate: jest.fn().mockImplementation((context) => {
+      const req = context.switchToHttp().getRequest();
+      req.session = {
+        user: { id: 'test-user-id', role: 'admin' },
+        session: { id: 'test-session-id' },
+      };
+      return true;
+    }),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(AuthGuard)
+      .useValue(mockAuthGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1', { exclude: ['health-check'] });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    auditLogRepository = moduleFixture.get(getRepositoryToken(AuditLog));
+    authToken = 'test-token';
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await auditLogRepository.query('DELETE FROM audit_logs');
+  });
+
+  const createTestAuditLog = async (overrides: Partial<AuditLog> = {}) => {
+    return auditLogRepository.save({
+      user_id: 'test-user-id',
+      action: AuditAction.CREATE,
+      entity_type: AuditEntityType.PRODUCT,
+      entity_id: '550e8400-e29b-41d4-a716-446655440000',
+      changes: null,
+      ip_address: '127.0.0.1',
+      user_agent: 'test-agent',
+      ...overrides,
+    });
+  };
+
+  describe('GET /api/v1/audit-logs', () => {
+    it('should return empty paginated response when no logs exist', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data).toEqual([]);
+      expect(response.body.meta.total).toBe(0);
+      expect(response.body.meta.page).toBe(1);
+    });
+
+    it('should return paginated audit logs', async () => {
+      await createTestAuditLog();
+      await createTestAuditLog({
+        action: AuditAction.UPDATE,
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data).toHaveLength(2);
+      expect(response.body.meta.total).toBe(2);
+      expect(response.body.meta.has_next).toBe(false);
+      expect(response.body.meta.has_previous).toBe(false);
+    });
+
+    it('should filter by action', async () => {
+      await createTestAuditLog({ action: AuditAction.CREATE });
+      await createTestAuditLog({
+        action: AuditAction.DELETE,
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({ action: AuditAction.CREATE })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].action).toBe(AuditAction.CREATE);
+    });
+
+    it('should filter by entity_type', async () => {
+      await createTestAuditLog({ entity_type: AuditEntityType.PRODUCT });
+      await createTestAuditLog({
+        entity_type: AuditEntityType.CATEGORY,
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({ entity_type: AuditEntityType.CATEGORY })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].entity_type).toBe(AuditEntityType.CATEGORY);
+    });
+
+    it('should filter by both action and entity_type', async () => {
+      await createTestAuditLog({
+        action: AuditAction.CREATE,
+        entity_type: AuditEntityType.PRODUCT,
+      });
+      await createTestAuditLog({
+        action: AuditAction.UPDATE,
+        entity_type: AuditEntityType.PRODUCT,
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      });
+      await createTestAuditLog({
+        action: AuditAction.CREATE,
+        entity_type: AuditEntityType.CATEGORY,
+        entity_id: '770e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({
+          action: AuditAction.CREATE,
+          entity_type: AuditEntityType.PRODUCT,
+        })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].action).toBe(AuditAction.CREATE);
+      expect(response.body.data[0].entity_type).toBe(AuditEntityType.PRODUCT);
+    });
+
+    it('should paginate results', async () => {
+      // Create 5 logs
+      for (let i = 0; i < 5; i++) {
+        await createTestAuditLog({
+          entity_id: `550e8400-e29b-41d4-a716-44665544000${i}`,
+        });
+      }
+
+      const page1 = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({ page: 1, limit: 2 })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(page1.body.data).toHaveLength(2);
+      expect(page1.body.meta.total).toBe(5);
+      expect(page1.body.meta.total_pages).toBe(3);
+      expect(page1.body.meta.has_next).toBe(true);
+      expect(page1.body.meta.has_previous).toBe(false);
+
+      const page2 = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({ page: 2, limit: 2 })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(page2.body.data).toHaveLength(2);
+      expect(page2.body.meta.has_next).toBe(true);
+      expect(page2.body.meta.has_previous).toBe(true);
+
+      const page3 = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .query({ page: 3, limit: 2 })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(page3.body.data).toHaveLength(1);
+      expect(page3.body.meta.has_next).toBe(false);
+      expect(page3.body.meta.has_previous).toBe(true);
+    });
+
+    it('should return logs ordered by created_at descending', async () => {
+      const older = await createTestAuditLog({
+        entity_id: '550e8400-e29b-41d4-a716-446655440001',
+      });
+      // Small delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const newer = await createTestAuditLog({
+        entity_id: '550e8400-e29b-41d4-a716-446655440002',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.data[0].id).toBe(newer.id);
+      expect(response.body.data[1].id).toBe(older.id);
+    });
+  });
+
+  describe('GET /api/v1/audit-logs/:id', () => {
+    it('should return a single audit log by id', async () => {
+      const auditLog = await createTestAuditLog();
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/v1/audit-logs/${auditLog.id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body.id).toBe(auditLog.id);
+      expect(response.body.action).toBe(AuditAction.CREATE);
+      expect(response.body.entity_type).toBe(AuditEntityType.PRODUCT);
+    });
+
+    it('should return 404 for non-existent audit log', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/audit-logs/550e8400-e29b-41d4-a716-446655440099')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404);
+    });
+
+    it('should return 400 for invalid UUID', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/audit-logs/not-a-uuid')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(400);
+    });
+  });
+
+  describe('GET /api/v1/audit-logs/entity/:entityType/:entityId', () => {
+    it('should return audit history for an entity', async () => {
+      const entityId = '550e8400-e29b-41d4-a716-446655440000';
+      await createTestAuditLog({
+        action: AuditAction.CREATE,
+        entity_type: AuditEntityType.PRODUCT,
+        entity_id: entityId,
+      });
+      await createTestAuditLog({
+        action: AuditAction.UPDATE,
+        entity_type: AuditEntityType.PRODUCT,
+        entity_id: entityId,
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/v1/audit-logs/entity/PRODUCT/${entityId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+    });
+
+    it('should return empty array for entity with no history', async () => {
+      const response = await request(app.getHttpServer())
+        .get(
+          '/api/v1/audit-logs/entity/PRODUCT/550e8400-e29b-41d4-a716-446655440099',
+        )
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+  });
+
+  describe('GET /api/v1/audit-logs/user/:userId', () => {
+    it('should return audit history for a user', async () => {
+      await createTestAuditLog({ user_id: 'specific-user-id' });
+      await createTestAuditLog({
+        user_id: 'specific-user-id',
+        entity_id: '660e8400-e29b-41d4-a716-446655440000',
+      });
+      await createTestAuditLog({ user_id: 'other-user-id' });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs/user/specific-user-id')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(
+        response.body.every(
+          (log: AuditLog) => log.user_id === 'specific-user-id',
+        ),
+      ).toBe(true);
+    });
+
+    it('should return empty array for user with no history', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/audit-logs/user/non-existent-user')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+  });
+
+  describe('Authorization', () => {
+    it('should return 403 when not authorized', async () => {
+      mockAuthGuard.canActivate.mockReturnValueOnce(false);
+
+      await request(app.getHttpServer())
+        .get('/api/v1/audit-logs')
+        .expect(403);
+    });
+  });
+});

--- a/modules/web/e2e/tests/audit-logs.spec.ts
+++ b/modules/web/e2e/tests/audit-logs.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+
+const NAVIGATION_TIMEOUT = 15000
+
+test.describe('Audit Logs Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/audit-logs')
+    // Wait for the page header to confirm load
+    await expect(
+      page.locator('h1', { hasText: /audit logs/i }),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT })
+  })
+
+  test('renders page header with title and subtitle', async ({ page }) => {
+    await expect(page.locator('h1', { hasText: /audit logs/i })).toBeVisible()
+    await expect(
+      page.locator('text=View system activity and changes'),
+    ).toBeVisible()
+  })
+
+  test('renders filter dropdowns', async ({ page }) => {
+    // Action filter
+    const actionTrigger = page.locator('button[role="combobox"]').first()
+    await expect(actionTrigger).toBeVisible()
+
+    // Entity type filter
+    const entityTypeTrigger = page.locator('button[role="combobox"]').nth(1)
+    await expect(entityTypeTrigger).toBeVisible()
+  })
+
+  test('renders table with correct column headers', async ({ page }) => {
+    const table = page.locator('table')
+    // Table may or may not be present depending on data; check headers if table exists
+    const tableExists = await table.isVisible().catch(() => false)
+
+    if (tableExists) {
+      await expect(table.locator('th', { hasText: /action/i })).toBeVisible()
+      await expect(table.locator('th', { hasText: /entity type/i })).toBeVisible()
+      await expect(table.locator('th', { hasText: /entity id/i })).toBeVisible()
+      await expect(table.locator('th', { hasText: /user id/i })).toBeVisible()
+      await expect(table.locator('th', { hasText: /ip address/i })).toBeVisible()
+      await expect(table.locator('th', { hasText: /date/i })).toBeVisible()
+    }
+  })
+
+  test('shows empty state or table data', async ({ page }) => {
+    // Either the table is rendered with data, or an empty state is shown
+    const table = page.locator('table')
+    const emptyState = page.locator('text=No audit logs found')
+
+    await expect(table.or(emptyState)).toBeVisible({ timeout: NAVIGATION_TIMEOUT })
+  })
+
+  test('action filter opens and shows options', async ({ page }) => {
+    const actionTrigger = page.locator('button[role="combobox"]').first()
+    await actionTrigger.click()
+
+    // Verify some action options appear
+    await expect(page.locator('[role="option"]', { hasText: /create/i })).toBeVisible()
+    await expect(page.locator('[role="option"]', { hasText: /update/i })).toBeVisible()
+    await expect(page.locator('[role="option"]', { hasText: /delete/i })).toBeVisible()
+  })
+
+  test('entity type filter opens and shows options', async ({ page }) => {
+    const entityTypeTrigger = page.locator('button[role="combobox"]').nth(1)
+    await entityTypeTrigger.click()
+
+    // Verify some entity type options appear
+    await expect(page.locator('[role="option"]', { hasText: /product/i })).toBeVisible()
+    await expect(page.locator('[role="option"]', { hasText: /category/i })).toBeVisible()
+    await expect(page.locator('[role="option"]', { hasText: /inventory/i })).toBeVisible()
+  })
+
+  test('selecting action filter updates URL and shows filter chip', async ({ page }) => {
+    const actionTrigger = page.locator('button[role="combobox"]').first()
+    await actionTrigger.click()
+
+    await page.locator('[role="option"]', { hasText: /create/i }).click()
+
+    // URL should contain the action param
+    await expect(page).toHaveURL(/action=CREATE/, { timeout: NAVIGATION_TIMEOUT })
+
+    // A filter chip should appear
+    await expect(
+      page.locator('button', { hasText: /action.*create/i }),
+    ).toBeVisible()
+
+    // Clear all button should appear
+    await expect(
+      page.locator('button', { hasText: /clear all/i }),
+    ).toBeVisible()
+  })
+
+  test('selecting entity type filter updates URL and shows filter chip', async ({ page }) => {
+    const entityTypeTrigger = page.locator('button[role="combobox"]').nth(1)
+    await entityTypeTrigger.click()
+
+    await page.locator('[role="option"]', { hasText: /product/i }).click()
+
+    // URL should contain the entity_type param
+    await expect(page).toHaveURL(/entity_type=PRODUCT/, { timeout: NAVIGATION_TIMEOUT })
+
+    // A filter chip should appear
+    await expect(
+      page.locator('button', { hasText: /entity type.*product/i }),
+    ).toBeVisible()
+  })
+
+  test('removing filter chip clears the filter from URL', async ({ page }) => {
+    // Apply a filter first
+    const actionTrigger = page.locator('button[role="combobox"]').first()
+    await actionTrigger.click()
+    await page.locator('[role="option"]', { hasText: /create/i }).click()
+
+    await expect(page).toHaveURL(/action=CREATE/, { timeout: NAVIGATION_TIMEOUT })
+
+    // Click the filter chip to remove it
+    const chip = page.locator('button', { hasText: /action.*create/i })
+    await chip.click()
+
+    // URL should no longer have the action param
+    await expect(page).not.toHaveURL(/action=CREATE/, { timeout: NAVIGATION_TIMEOUT })
+  })
+
+  test('clear all button removes all filters', async ({ page }) => {
+    // Apply action filter
+    const actionTrigger = page.locator('button[role="combobox"]').first()
+    await actionTrigger.click()
+    await page.locator('[role="option"]', { hasText: /create/i }).click()
+    await expect(page).toHaveURL(/action=CREATE/, { timeout: NAVIGATION_TIMEOUT })
+
+    // Apply entity type filter
+    const entityTypeTrigger = page.locator('button[role="combobox"]').nth(1)
+    await entityTypeTrigger.click()
+    await page.locator('[role="option"]', { hasText: /product/i }).click()
+    await expect(page).toHaveURL(/entity_type=PRODUCT/, { timeout: NAVIGATION_TIMEOUT })
+
+    // Click clear all
+    await page.locator('button', { hasText: /clear all/i }).click()
+
+    // URL should be clean
+    await expect(page).toHaveURL('/audit-logs', { timeout: NAVIGATION_TIMEOUT })
+  })
+
+  test('navigating directly with search params applies filters', async ({ page }) => {
+    await page.goto('/audit-logs?action=DELETE&entity_type=CATEGORY')
+
+    // Filter chips should be visible
+    await expect(
+      page.locator('button', { hasText: /action.*delete/i }),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT })
+    await expect(
+      page.locator('button', { hasText: /entity type.*category/i }),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT })
+  })
+})

--- a/modules/web/playwright.config.ts
+++ b/modules/web/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         storageState: 'e2e/.auth/user.json',
       },
       dependencies: ['setup'],
-      testMatch: /navigation\.spec\.ts/,
+      testMatch: /(?:navigation|audit-logs)\.spec\.ts/,
     },
     {
       name: 'unauthenticated',

--- a/modules/web/src/components/audit-logs/LogTable.tsx
+++ b/modules/web/src/components/audit-logs/LogTable.tsx
@@ -1,34 +1,193 @@
 'use client'
-import { useListAuditLogs } from '@/lib/data/audit-logs'
 
-export function LogTable(): React.JSX.Element {
-  const { data, isError } = useListAuditLogs()
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { EmptyState } from '@/components/common/EmptyState'
+import { ErrorState } from '@/components/common/ErrorState'
+import { PaginationControls } from '@/components/common/PaginationControls'
+import {
+  useListAuditLogs,
+  AuditAction,
+  type AuditLogQueryDto,
+  type AuditLogResponseDto,
+} from '@/lib/data/audit-logs'
+import { cn } from '@/lib/utils'
+
+interface LogTableProps {
+  filters?: Partial<AuditLogQueryDto>
+  page: number
+  limit: number
+  hasActiveFilters: boolean
+  onPageChange: (page: number) => void
+}
+
+const ACTION_BADGE_CLASSES: Record<AuditAction, string> = {
+  [AuditAction.CREATE]: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  [AuditAction.UPDATE]: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  [AuditAction.DELETE]: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  [AuditAction.RESTORE]: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  [AuditAction.ADJUST_QUANTITY]: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  [AuditAction.ADD_PHOTO]: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400',
+  [AuditAction.STATUS_CHANGE]: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
+}
+
+function truncateUuid(uuid: string): string {
+  return uuid.length > 8 ? `${uuid.slice(0, 8)}…` : uuid
+}
+
+function TableSkeleton(): React.JSX.Element {
+  return (
+    <TableBody>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <TableRow key={`skeleton-row-${String(i)}`}>
+          <TableCell>
+            <Skeleton className="h-5 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-32" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  )
+}
+
+function LogRow({ log }: { log: AuditLogResponseDto }): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const actionLabel = t(`auditLogs.actions.${log.action}`, { defaultValue: log.action })
+  const entityLabel = t(`auditLogs.entityTypes.${log.entity_type}`, { defaultValue: log.entity_type })
+  const systemLabel = t('auditLogs.system', { defaultValue: 'System' })
 
   return (
-    <div>
-      {data && !isError
-        ? data.data.map((log) => (
-            <div
-              key={log.id}
-              style={{
-                border: '1px solid black',
-                margin: '10px',
-                padding: '10px',
-              }}
-            >
-              <p>
-                <strong>ID:</strong> {log.id}
-              </p>
-              <p>
-                <strong>Action:</strong> {log.action}
-              </p>
-              <p>
-                <strong>Timestamp:</strong>{' '}
-                {new Date(log.created_at).toLocaleString()}
-              </p>
-            </div>
-          ))
-        : 'Loading...'}
+    <TableRow>
+      <TableCell>
+        <Badge
+          className={cn('border-transparent', ACTION_BADGE_CLASSES[log.action])}
+          variant="outline"
+        >
+          {actionLabel}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant="secondary">{entityLabel}</Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground font-mono text-xs" title={log.entity_id}>
+        {truncateUuid(log.entity_id)}
+      </TableCell>
+      <TableCell className="text-muted-foreground font-mono text-xs" title={log.user_id ?? undefined}>
+        {log.user_id ? truncateUuid(log.user_id) : systemLabel}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">
+        {log.ip_address ?? '—'}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">
+        {new Date(log.created_at).toLocaleString()}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function LogTable({
+  filters,
+  page,
+  limit,
+  hasActiveFilters,
+  onPageChange,
+}: LogTableProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const queryParams = React.useMemo(
+    () => ({
+      page,
+      limit,
+      ...filters,
+    }),
+    [filters, limit, page],
+  )
+
+  const { data, isLoading, error } = useListAuditLogs(queryParams)
+
+  const logs = data?.data ?? []
+  const meta = data?.meta
+
+  if (error) {
+    return (
+      <ErrorState
+        message={t('auditLogs.errorLoading', { defaultValue: 'Error loading audit logs' })}
+        variant="bordered"
+      />
+    )
+  }
+
+  if (!isLoading && logs.length === 0) {
+    return (
+      <EmptyState
+        variant="bordered"
+        message={
+          hasActiveFilters
+            ? t('auditLogs.noLogsFiltered', { defaultValue: 'No results for these filters' })
+            : t('auditLogs.noLogs', { defaultValue: 'No audit logs found' })
+        }
+      />
+    )
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t('auditLogs.action', { defaultValue: 'Action' })}</TableHead>
+            <TableHead>{t('auditLogs.entityType', { defaultValue: 'Entity Type' })}</TableHead>
+            <TableHead>{t('auditLogs.entityId', { defaultValue: 'Entity ID' })}</TableHead>
+            <TableHead>{t('auditLogs.userId', { defaultValue: 'User ID' })}</TableHead>
+            <TableHead>{t('auditLogs.ipAddress', { defaultValue: 'IP Address' })}</TableHead>
+            <TableHead>{t('auditLogs.date', { defaultValue: 'Date' })}</TableHead>
+          </TableRow>
+        </TableHeader>
+        {isLoading ? (
+          <TableSkeleton />
+        ) : (
+          <TableBody>
+            {logs.map((log) => (
+              <LogRow key={log.id} log={log} />
+            ))}
+          </TableBody>
+        )}
+      </Table>
+      <div className="px-4 pb-4">
+        <PaginationControls
+          isLoading={isLoading}
+          page={page}
+          totalItems={meta?.total}
+          totalPages={meta?.total_pages ?? 1}
+          onPageChange={onPageChange}
+        />
+      </div>
     </div>
   )
 }

--- a/modules/web/src/locales/en/common.json
+++ b/modules/web/src/locales/en/common.json
@@ -180,6 +180,43 @@
     "deleted": "Area deleted successfully",
     "deleteError": "Failed to delete area"
   },
+  "auditLogs": {
+    "title": "Audit Logs",
+    "subtitle": "View system activity and changes",
+    "noLogs": "No audit logs found",
+    "noLogsFiltered": "No results for these filters",
+    "errorLoading": "Error loading audit logs",
+    "action": "Action",
+    "entityType": "Entity Type",
+    "entityId": "Entity ID",
+    "userId": "User ID",
+    "ipAddress": "IP Address",
+    "date": "Date",
+    "allActions": "All Actions",
+    "allEntityTypes": "All Entity Types",
+    "system": "System",
+    "actions": {
+      "CREATE": "Create",
+      "UPDATE": "Update",
+      "DELETE": "Delete",
+      "RESTORE": "Restore",
+      "ADJUST_QUANTITY": "Adjust Quantity",
+      "ADD_PHOTO": "Add Photo",
+      "STATUS_CHANGE": "Status Change"
+    },
+    "entityTypes": {
+      "PRODUCT": "Product",
+      "CATEGORY": "Category",
+      "SUPPLIER": "Supplier",
+      "ORDER": "Order",
+      "ORDER_ITEM": "Order Item",
+      "INVENTORY": "Inventory",
+      "LOCATION": "Location",
+      "STOCK_MOVEMENT": "Stock Movement",
+      "PHOTO": "Photo",
+      "AREA": "Area"
+    }
+  },
   "inventory": {
     "subtitle": "Track stock levels across locations",
     "allInventory": "All Inventory",

--- a/modules/web/src/routes/audit-logs.tsx
+++ b/modules/web/src/routes/audit-logs.tsx
@@ -1,16 +1,201 @@
+import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
+import { z } from 'zod'
 
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { LogTable } from '@/components/audit-logs/LogTable'
+import {
+  AuditAction,
+  AuditEntityType,
+  type AuditLogQueryDto,
+} from '@/lib/data/audit-logs'
+import { parseNumberParam, parseStringParam } from '@/lib/router/search'
+
+const auditLogsSearchSchema = z.object({
+  page: z.preprocess(parseNumberParam, z.number().int().min(1).optional()),
+  action: z.preprocess(parseStringParam, z.string().optional()),
+  entity_type: z.preprocess(parseStringParam, z.string().optional()),
+})
+
+const AUDIT_LOG_PAGE_SIZE = 50
 
 export const Route = createFileRoute('/audit-logs')({
+  validateSearch: (search) => auditLogsSearchSchema.parse(search),
   component: AuditPage,
 })
 
+type AuditLogsSearch = ReturnType<typeof Route.useSearch>
+
 function AuditPage(): React.JSX.Element {
+  const { t } = useTranslation()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  const page = search.page ?? 1
+  const action = search.action as AuditAction | undefined
+  const entityType = search.entity_type as AuditEntityType | undefined
+
+  const filters = React.useMemo(() => {
+    const f: Partial<AuditLogQueryDto> = {}
+    if (action) f.action = action
+    if (entityType) f.entity_type = entityType
+    return f
+  }, [action, entityType])
+
+  const filterChips = React.useMemo(() => {
+    const chips: { key: string; label: string; onRemove: () => void }[] = []
+    if (action) {
+      chips.push({
+        key: 'action',
+        label: `${t('auditLogs.action', { defaultValue: 'Action' })}: ${t(`auditLogs.actions.${action}`, { defaultValue: action })}`,
+        onRemove: () => {
+          void navigate({
+            search: (prev: AuditLogsSearch) => ({
+              ...prev,
+              action: undefined,
+              page: 1,
+            }),
+            replace: true,
+          })
+        },
+      })
+    }
+    if (entityType) {
+      chips.push({
+        key: 'entity_type',
+        label: `${t('auditLogs.entityType', { defaultValue: 'Entity Type' })}: ${t(`auditLogs.entityTypes.${entityType}`, { defaultValue: entityType })}`,
+        onRemove: () => {
+          void navigate({
+            search: (prev: AuditLogsSearch) => ({
+              ...prev,
+              entity_type: undefined,
+              page: 1,
+            }),
+            replace: true,
+          })
+        },
+      })
+    }
+    return chips
+  }, [action, entityType, navigate, t])
+
+  const hasActiveFilters = filterChips.length > 0
+
+  const clearAll = (): void => {
+    void navigate({ search: {}, replace: true })
+  }
+
   return (
-    <>
-      <h1>Audit Logs</h1>
-      <LogTable />
-    </>
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <div>
+          <h1 className="text-xl font-semibold">
+            {t('auditLogs.title', { defaultValue: 'Audit Logs' })}
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            {t('auditLogs.subtitle', { defaultValue: 'View system activity and changes' })}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 border-b px-6 py-3">
+        <Select
+          value={action ?? ''}
+          onValueChange={(value) => {
+            void navigate({
+              search: (prev: AuditLogsSearch) => ({
+                ...prev,
+                action: value || undefined,
+                page: 1,
+              }),
+              replace: true,
+            })
+          }}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder={t('auditLogs.allActions', { defaultValue: 'All Actions' })} />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.values(AuditAction).map((a) => (
+              <SelectItem key={a} value={a}>
+                {t(`auditLogs.actions.${a}`, { defaultValue: a })}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={entityType ?? ''}
+          onValueChange={(value) => {
+            void navigate({
+              search: (prev: AuditLogsSearch) => ({
+                ...prev,
+                entity_type: value || undefined,
+                page: 1,
+              }),
+              replace: true,
+            })
+          }}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder={t('auditLogs.allEntityTypes', { defaultValue: 'All Entity Types' })} />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.values(AuditEntityType).map((et) => (
+              <SelectItem key={et} value={et}>
+                {t(`auditLogs.entityTypes.${et}`, { defaultValue: et })}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2 border-b px-6 py-2">
+          {filterChips.map((chip) => (
+            <Button
+              key={chip.key}
+              className="gap-1"
+              size="sm"
+              variant="outline"
+              onClick={chip.onRemove}
+            >
+              {chip.label}
+              <X className="size-3" />
+            </Button>
+          ))}
+          <Button size="sm" variant="ghost" onClick={clearAll}>
+            {t('actions.clearAll', { defaultValue: 'Clear all' })}
+          </Button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto p-6">
+        <LogTable
+          filters={filters}
+          hasActiveFilters={hasActiveFilters}
+          limit={AUDIT_LOG_PAGE_SIZE}
+          page={page}
+          onPageChange={(nextPage) => {
+            void navigate({
+              search: (prev: AuditLogsSearch) => ({
+                ...prev,
+                page: nextPage,
+              }),
+              replace: true,
+            })
+          }}
+        />
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
This pull request introduces comprehensive audit log testing and documentation for the API, along with minor documentation updates for the web module. The most significant changes are the addition of unit and end-to-end tests for audit log functionality, new documentation for audit log endpoints and testing practices, and clarification of TanStack Router usage in the frontend.

**Audit Log Testing and Documentation**

* Added detailed audit log endpoint documentation, including authentication requirements and available filters, to `modules/api/CLAUDE.md`.
* Added Jest unit tests for `AuditLogRepository` covering creation, retrieval, filtering, and pagination logic in `modules/api/src/routes/audit-logs/audit-log.repository.spec.ts`.
* Added end-to-end tests for audit log API endpoints, including paginated listing, filtering, entity/user history, and authorization checks in `modules/api/test/audit-logs.e2e-spec.ts`.
* Documented testing commands and patterns for both unit and e2e tests in API and web modules, including notes on Jest 30 argument changes in `CLAUDE.md`.

**Frontend Documentation Updates**

* Updated TanStack Router documentation to reflect correct usage of the `src/routes/` directory instead of `src/app/` in `modules/web/CLAUDE.md`. [[1]](diffhunk://#diff-3c0145de741ace00b008274b9cde8deac41056aced6151af165f468a9a4a2dc2L14-R14) [[2]](diffhunk://#diff-3c0145de741ace00b008274b9cde8deac41056aced6151af165f468a9a4a2dc2L47-R47) [[3]](diffhunk://#diff-3c0145de741ace00b008274b9cde8deac41056aced6151af165f468a9a4a2dc2L201-R209)